### PR TITLE
Require Attr form of slog logging

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,6 +16,8 @@ linters:
   settings:
     misspell:
       locale: US
+    sloglint:
+      attr-only: true
   exclusions:
     presets:
       - std-error-handling


### PR DESCRIPTION
Inspired by advice from this blog post:

https://www.dash0.com/guides/logging-in-go-with-slog

If this turns out to be annoying, we can turn it off again.
