### PR TITLE
Add basic configuration validation

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/letsencrypt/test-certs-site/config"
@@ -54,5 +55,27 @@ func TestLoadConfig(t *testing.T) {
 
 	if !reflect.DeepEqual(cfg, &expected) {
 		t.Fatalf("got:\n%+q\nwant:\n%+q", cfg, &expected)
+	}
+}
+
+func TestInvalidConfig(t *testing.T) {
+	t.Parallel()
+	_, err := config.Load("invalid.json")
+	if err == nil {
+		t.Fatal("LoadConfig should have returned an error on invalid json")
+	}
+
+	errStr := err.Error()
+
+	for _, expected := range []string{
+		"site 0 missing issuer CN",
+		"site 0 duplicate domain: duplicate.domain",
+		"site 1 duplicate domain: valid.salad",
+		"site 0 unsupported key type: 3des",
+		"site 1 unsupported key type: ",
+	} {
+		if !strings.Contains(errStr, expected) {
+			t.Errorf("got error %q, want error containing %q", errStr, expected)
+		}
 	}
 }

--- a/config/invalid.json
+++ b/config/invalid.json
@@ -1,0 +1,20 @@
+{
+  "sites": [
+    {
+      "keyType": "3des",
+      "domains": {
+        "valid": "valid.salad",
+        "expired": "duplicate.domain",
+        "revoked": "duplicate.domain"
+      }
+    },
+    {
+      "issuerCN": "root",
+      "domains": {
+        "valid": "valid.salad",
+        "expired": "expired.salad",
+        "revoked": "revoked.salad"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This adds a check that the key types are valid, that an issuer CN is present, and that domains aren't duplicated.