### PR TITLE
Run a webserver

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,6 +11,7 @@ linters:
     - perfsprint
     - testpackage
     - varnamelen
+    - wrapcheck
     - wsl
     - wsl_v5
   settings:

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,9 @@ func Load(cfgPath string) (*Config, error) {
 
 // Config is the structure of the JSON configuration file.
 type Config struct {
+	// ListenAddr for the demo site to listen on. Eg, ":443".
+	ListenAddr string
+
 	// Sites is a list of sites to host.
 	Sites []Site
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,6 +11,8 @@ import (
 func TestLoadConfig(t *testing.T) {
 	t.Parallel()
 	expected := config.Config{
+		ListenAddr: "localhost:8443",
+
 		Sites: []config.Site{
 			{
 				IssuerCN: "minica root ca 5345e6",

--- a/config/test.json
+++ b/config/test.json
@@ -1,4 +1,6 @@
 {
+  "listenAddr": "localhost:8443",
+
   "sites": [
     {
       "issuerCN": "minica root ca 5345e6",

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func run(args []string) error {
 	if err != nil {
 		return fmt.Errorf("loading temporary certificate: %w", err)
 	}
-	todoGetCert := func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	todoGetCert := func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		return &temporaryStaticCert, nil
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,67 @@
+// Package server is the HTTPS server for test-certs-site.
+package server
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// handle an http request with a placeholder response.
+func handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet || r.URL.Path != "/" {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, "404 Not Found")
+
+		return
+	}
+
+	// This is just a placeholder until we make a nice site.
+	_, _ = fmt.Fprintf(w, "This is a demontration site for %s", r.TLS.ServerName)
+}
+
+// GetCertificateFunc is the type of the TLSConfig.GetCertificate function.
+// The webserver will use it to obtain certificates, including fulfilling
+// ACME TLS-ALPN-01 challenges.
+type GetCertificateFunc func(info *tls.ClientHelloInfo) (*tls.Certificate, error)
+
+// Run the server, until the process is signaled to exit.
+func Run(addr string, getCert GetCertificateFunc) error {
+	// We want http requests to time out relatively quickly, as this server shouldn't be doing much.
+	const timeout = 5 * time.Second
+
+	srv := http.Server{
+		Addr:    addr,
+		Handler: http.HandlerFunc(handle),
+
+		IdleTimeout:       timeout,
+		ReadHeaderTimeout: timeout,
+		ReadTimeout:       timeout,
+		WriteTimeout:      timeout,
+
+		TLSConfig: &tls.Config{
+			GetCertificate: getCert,
+			MinVersion:     tls.VersionTLS12,
+		},
+	}
+
+	// Wait for a signal to shut down the server.
+	go func() {
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+		<-sigChan
+
+		err := srv.Shutdown(context.Background())
+		if err != nil {
+			slog.Error(err.Error())
+		}
+	}()
+
+	return srv.ListenAndServeTLS("", "")
+}


### PR DESCRIPTION
This runs a simple webserver to host the demonstration certificates.

Right now, there's a placeholder which loads a key pair from files. This is going to be deleted in an upcoming PR, but is enough to get started without making this PR too big.

The page content is also a plain text message, pending adding a better page content to be rendered.

This PR disables the wrapcheck linter because I think it's not always helpful, and we should consider on a case-by-case basis on when wrapping errors is useful. They're not stack traces.
