### PR TITLE
Explicitly allow old TLS

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -33,6 +33,7 @@ func Run(cfg *config.Config, getCert GetCertificateFunc) error {
 		ReadTimeout:       timeout,
 		WriteTimeout:      timeout,
 
+		//nolint:gosec // This is an explicit TLS test site, so allow TLS1.0
 		TLSConfig: &tls.Config{
 			GetCertificate: getCert,
 			MinVersion:     tls.VersionTLS10,


### PR DESCRIPTION
Our goal with these sites is to test compatibility with our roots.

The most likely problems are with old clients, which may not support
TLS 1.3 or even TLS 1.2.

Since this is a dedicated test site, there's no security risk associated,
so we can safely enable TLS 1.0.
