### PR TITLE
Make storage take PEM we get from lego

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -171,26 +171,15 @@ func (s *Storage) StoreNextKey(domain string, keyType string) (crypto.Signer, er
 }
 
 // StoreNextCert stores the next certificate for the domain.
-// Certificates should be a sequence of DER certificates.
-func (s *Storage) StoreNextCert(domain string, certificates [][]byte) error {
+// Certificates should be a PEM sequence to write to disk.
+func (s *Storage) StoreNextCert(domain string, certificates []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	certPath := s.pathFor(domain, next, certificateFilename)
-	cert, err := os.OpenFile(certPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, certPerms) //nolint:gosec // Arbitrary file is not a risk here
+	err := os.WriteFile(certPath, certificates, certPerms)
 	if err != nil {
-		return fmt.Errorf("could not open certificate file: %w", err)
-	}
-	defer cert.Close()
-
-	for _, data := range certificates {
-		err := pem.Encode(cert, &pem.Block{
-			Type:  "CERTIFICATE",
-			Bytes: data,
-		})
-		if err != nil {
-			return fmt.Errorf("could not write certificate: %w", err)
-		}
+		return fmt.Errorf("could not write certificate: %w", err)
 	}
 
 	return nil

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"os"
 	"testing"
@@ -69,7 +70,7 @@ func TestStorage(t *testing.T) {
 }
 
 // testCert returns a test self-signed cert for the given key.
-func testCert(t *testing.T, domain string, key crypto.Signer) [][]byte {
+func testCert(t *testing.T, domain string, key crypto.Signer) []byte {
 	t.Helper()
 
 	// Create a certificate template
@@ -82,7 +83,10 @@ func testCert(t *testing.T, domain string, key crypto.Signer) [][]byte {
 		t.Fatalf("Failed to create certificate: %v", err)
 	}
 
-	return [][]byte{certDER}
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
 }
 
 func TestAccountStorage(t *testing.T) {


### PR DESCRIPTION
The Lego ACME client returns certificates formatted as PEM, ready to be written
to disk. Update the storage API to take those PEM instead of encoding ourselves.
