### PR TITLE
Include x509roots/fallback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
 module github.com/letsencrypt/test-certs-site
 
-go 1.25
+go 1.25.0
 
-require github.com/go-acme/lego/v4 v4.32.0
+require (
+	github.com/go-acme/lego/v4 v4.32.0
+	golang.org/x/crypto/x509roots/fallback v0.0.0-20260311141749-982eaa62dfb7
+)
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
 golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
+golang.org/x/crypto/x509roots/fallback v0.0.0-20260311141749-982eaa62dfb7 h1:uX5F+sUnmp3J14eF1J92KuF4wi4GP4lnnEbFfwuNVVU=
+golang.org/x/crypto/x509roots/fallback v0.0.0-20260311141749-982eaa62dfb7/go.mod h1:+UoQFNBq2p2wO+Q6ddVtYc25GZ6VNdOMyyrd4nrqrKs=
 golang.org/x/mod v0.32.0 h1:9F4d3PHLljb6x//jOyokMv3eX+YDeepZSEo3mFJy93c=
 golang.org/x/mod v0.32.0/go.mod h1:SgipZ/3h2Ci89DlEtEXWUk/HteuRin+HHhN+WbNhguU=
 golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=

--- a/main.go
+++ b/main.go
@@ -16,6 +16,8 @@ import (
 	"github.com/letsencrypt/test-certs-site/scheduler"
 	"github.com/letsencrypt/test-certs-site/server"
 	"github.com/letsencrypt/test-certs-site/storage"
+
+	_ "golang.org/x/crypto/x509roots/fallback" // Include fallback roots for talking to ACME server
 )
 
 func run(args []string) error {


### PR DESCRIPTION
This allows deploying test-certs-site to a minimal container without OS root certs, but still being able to communicate with Let's Encrypt.

CI / Test / non-public environments can still bring their own root CA, as is done in the integration tests here.
And if your container or OS has root CAs, the fallback roots won't be used.
