### PR TITLE
Add favicon

### DIFF
--- a/server/page.html
+++ b/server/page.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
     <meta name="description" content="Website for compatibility testing.">
+    <link rel="icon" href="https://letsencrypt.org/favicon.ico">
 
     <style>
         body {
@@ -50,7 +51,6 @@
     </style>
 
     <title>{{.Domain}}</title>
-    <link rel="icon" href="https://letsencrypt.org/favicon.ico">
 </head>
 <body>
 


### PR DESCRIPTION
Just link out to the one we serve on letsencrypt.org, since we already do that for the image.

I outsourced my thinking to a clanker (OpenCode 1.2.27+Qwen3.5-27B_Q8_0) but validated that it works as expected locally.