### PR TITLE
Add a delay to wait to use a revoked certificate

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -152,6 +152,18 @@ func New(cfg *config.Config, store *storage.Storage, schedule *scheduler.Schedul
 		Timeout: time.Minute,
 	}
 
+	crlCheckInterval := time.Duration(cfg.CRLCheckInterval)
+	if crlCheckInterval == 0 {
+		// An hour is a reasonable approximation of how long it might take for a new CRL to be issued.
+		crlCheckInterval = time.Hour
+	}
+
+	revokeDelay := time.Duration(cfg.RevokeDelay)
+	if revokeDelay == 0 {
+		// 25 hours is long enough for CRLite and Windows CRL caches, including 1h backdating.
+		revokeDelay = 25 * time.Hour //nolint:mnd
+	}
+
 	for _, site := range cfg.Sites {
 		for domain, c := range map[string]checker{
 			site.Domains.Valid: &valid{
@@ -161,7 +173,8 @@ func New(cfg *config.Config, store *storage.Storage, schedule *scheduler.Schedul
 			site.Domains.Revoked: &revoked{
 				http:          crlClient,
 				logger:        slog.With(slog.String("domain", site.Domains.Revoked)),
-				checkInterval: time.Hour,
+				checkInterval: crlCheckInterval,
+				delay:         revokeDelay,
 			},
 			site.Domains.Expired: expired{},
 		} {

--- a/acme/check_revoked.go
+++ b/acme/check_revoked.go
@@ -77,7 +77,7 @@ func (r *revoked) checkReady(ctx context.Context, cert, issuer *x509.Certificate
 	// Wait for a delay to allow revocation information to propagate
 	delayUntil := cert.NotBefore.Add(r.delay)
 	if now.Before(delayUntil) {
-		r.logger.Info("Waiting for certificate to be revoked", slog.Time("at", delayUntil))
+		r.logger.Info("Delaying before using revoked certificate", slog.Time("at", delayUntil))
 
 		return delayUntil, nil
 	}

--- a/acme/check_revoked.go
+++ b/acme/check_revoked.go
@@ -16,6 +16,7 @@ type revoked struct {
 	logger *slog.Logger
 
 	checkInterval time.Duration
+	delay         time.Duration
 }
 
 func (r *revoked) checkCRL(ctx context.Context, cert, issuer *x509.Certificate) (bool, error) {
@@ -68,19 +69,28 @@ func (r *revoked) checkCRL(ctx context.Context, cert, issuer *x509.Certificate) 
 }
 
 func (r *revoked) checkReady(ctx context.Context, cert, issuer *x509.Certificate) (time.Time, error) {
-	if time.Now().After(cert.NotAfter) {
+	now := time.Now()
+	if now.After(cert.NotAfter) {
 		return time.Time{}, fmt.Errorf("certificate expired: %s", cert.NotAfter.Format(time.DateTime))
+	}
+
+	// Wait for a delay to allow revocation information to propagate
+	delayUntil := cert.NotBefore.Add(r.delay)
+	if now.Before(delayUntil) {
+		r.logger.Info("Waiting for certificate to be revoked", slog.Time("at", delayUntil))
+
+		return delayUntil, nil
 	}
 
 	isRevoked, err := r.checkCRL(ctx, cert, issuer)
 	if err != nil {
 		r.logger.Warn("Error checking CRL", slogErr(err))
 
-		return time.Now().Add(r.checkInterval), nil
+		return now.Add(r.checkInterval), nil
 	}
 
 	if !isRevoked {
-		retryAt := time.Now().Add(r.checkInterval)
+		retryAt := now.Add(r.checkInterval)
 		r.logger.Info("Certificate not yet revoked: will recheck", slog.Time("at", retryAt))
 
 		return retryAt, nil

--- a/acme/check_revoked_test.go
+++ b/acme/check_revoked_test.go
@@ -50,27 +50,43 @@ func TestCheckRevoked(t *testing.T) {
 		http:          server.Client(),
 		logger:        slog.Default(),
 		checkInterval: time.Minute,
+		delay:         time.Hour,
 	}
 
 	if !r.shouldRevoke() {
 		t.Fatal("revoked certs should revoke")
 	}
 
+	now := time.Now()
+
 	readyTime, err := r.checkReady(t.Context(), &x509.Certificate{
+		NotBefore: now,
+		NotAfter:  now.Add(time.Hour),
+	}, caCert)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if readyTime.Before(now.Add(r.delay)) {
+		t.Fatalf("should have waited for revocation delay, got %v", readyTime)
+	}
+
+	readyTime, err = r.checkReady(t.Context(), &x509.Certificate{
 		SerialNumber:          big.NewInt(1111),
-		NotAfter:              time.Now().Add(time.Hour),
+		NotBefore:             now.Add(-r.delay),
+		NotAfter:              now.Add(time.Hour),
 		CRLDistributionPoints: []string{server.URL + crlPath},
 	}, caCert)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if readyTime.Before(time.Now()) {
+	if readyTime.Before(now) {
 		t.Fatal("1111 isn't in CRL, should not be ready")
 	}
 
 	readyTime, err = r.checkReady(t.Context(), &x509.Certificate{
 		SerialNumber:          big.NewInt(12345),
-		NotAfter:              time.Now().Add(time.Hour),
+		NotBefore:             now.Add(-r.delay),
+		NotAfter:              now.Add(time.Hour),
 		CRLDistributionPoints: []string{server.URL + crlPath},
 	}, caCert)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -100,7 +100,7 @@ type Config struct {
 	// LogDebug enables debug level logs when set to true
 	LogDebug bool
 
-	// RevokeDelay is how long after revoking to wait to use a certificate, from the certificate's NotBefore time.
+	// RevokeDelay wait to use a revoked certificate, from the certificate's NotBefore time.
 	RevokeDelay Duration
 
 	// CRLCheckInterval is the re-checking interval for CRLs

--- a/config/config.go
+++ b/config/config.go
@@ -99,6 +99,12 @@ type Config struct {
 
 	// LogDebug enables debug level logs when set to true
 	LogDebug bool
+
+	// RevokeDelay is how long after revoking to wait to use a certificate, from the certificate's NotBefore time.
+	RevokeDelay Duration
+
+	// CRLCheckInterval is the re-checking interval for CRLs
+	CRLCheckInterval Duration
 }
 
 // Site configures a particular site.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/letsencrypt/test-certs-site/config"
 )
@@ -42,9 +43,11 @@ func TestLoadConfig(t *testing.T) {
 			TermsOfServiceAgreed: true,
 		},
 
-		DataDir:      "testdata/data_dir/",
-		HTMLTemplate: "testdata/template.html",
-		TextTemplate: "testdata/template.txt",
+		DataDir:          "testdata/data_dir/",
+		HTMLTemplate:     "testdata/template.html",
+		TextTemplate:     "testdata/template.txt",
+		RevokeDelay:      config.Duration(time.Hour),
+		CRLCheckInterval: config.Duration(time.Minute),
 	}
 
 	_, err := config.Load("non-existant.json")

--- a/config/json_duration.go
+++ b/config/json_duration.go
@@ -8,6 +8,7 @@ import (
 // Duration adds JSON unmarshalling to time.Duration
 type Duration time.Duration
 
+// UnmarshalJSON as a string, parsing with time.ParseDuration
 func (d *Duration) UnmarshalJSON(bytes []byte) error {
 	var str string
 	if err := json.Unmarshal(bytes, &str); err != nil {

--- a/config/json_duration.go
+++ b/config/json_duration.go
@@ -11,7 +11,8 @@ type Duration time.Duration
 // UnmarshalJSON as a string, parsing with time.ParseDuration
 func (d *Duration) UnmarshalJSON(bytes []byte) error {
 	var str string
-	if err := json.Unmarshal(bytes, &str); err != nil {
+	err := json.Unmarshal(bytes, &str)
+	if err != nil {
 		return err
 	}
 	dur, err := time.ParseDuration(str)

--- a/config/json_duration.go
+++ b/config/json_duration.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Duration adds JSON unmarshalling to time.Duration
+type Duration time.Duration
+
+func (d *Duration) UnmarshalJSON(bytes []byte) error {
+	var str string
+	if err := json.Unmarshal(bytes, &str); err != nil {
+		return err
+	}
+	dur, err := time.ParseDuration(str)
+	if err != nil {
+		return err
+	}
+
+	*d = Duration(dur)
+
+	return nil
+}

--- a/config/testdata/test.json
+++ b/config/testdata/test.json
@@ -29,5 +29,7 @@
   },
   "dataDir": "testdata/data_dir/",
   "htmlTemplate": "testdata/template.html",
-  "textTemplate": "testdata/template.txt"
+  "textTemplate": "testdata/template.txt",
+  "revokeDelay": "1h",
+  "CRLCheckInterval": "1m"
 }

--- a/integration/test-certs-site-config.json
+++ b/integration/test-certs-site-config.json
@@ -16,5 +16,7 @@
     "termsOfServiceAgreed": true
   },
   "dataDir": "/data",
-  "logDebug": true
+  "logDebug": true,
+  "revokeDelay": "1s",
+  "CRLCheckInterval": "1s"
 }


### PR DESCRIPTION
Revocation information can take a while to propogate, so we want to wait before using a certificate. Defaults to 25 hours, but is configurable.

25 hours is 1 hour backdate + 24 hours, which is more than the 12 hour update interval for CRLite, more than the MMD of all CT logs, and more than the maximum 24 hour CRL cache in Windows.

The revocation delay uses the certificate's NotBefore time so that the behaviour can be consistent even through process restarts. We know we revoke the certificate just after issuing it.

Also make the CRL re-check interval configurable.

fixes #54 